### PR TITLE
feat!: drop PHP 8.0 & PHP 8.1 support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
   security:
     uses: dvsa/.github/.github/workflows/php-library-security.yml@main
     with:
-      php-versions: "[\"8.0\", \"8.1\", \"8.2\", \"8.3\"]"
+      php-versions: "[\"8.2\", \"8.3\"]"
     secrets:
       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 
@@ -21,5 +21,5 @@ jobs:
   tests:
     uses: dvsa/.github/.github/workflows/php-library-tests.yml@main
     with:
-      php-versions: "[\"8.0\", \"8.1\", \"8.2\", \"8.3\"]"
+      php-versions: "[\"8.2\", \"8.3\"]"
       fail-fast: false

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ composer.phar
 composer.lock
 
 # PHPUnit
-.phpunit.result.cache
+.phpunit.cache
 
 # PHP-CS-Fixer
 .php-cs-fixer.cache

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This Composer library facilitates the use of Laminas config placeholders, enabli
     use Dvsa\LaminasConfigCloudParameters\Cast\Integer;
 
     return [
-        'config' => [
+        'config_parameters' => [
             'providers' => [
                 SecretsManager::class => [
                     'example-secret',
@@ -72,7 +72,7 @@ Only secrets that are stored in key/value pairs are supported.
 <?php
 
 return [
-    'config' => [
+    'config_parameters' => [
         'providers' => [
             SecretsManager::class => [
                 'global-secrets',
@@ -97,7 +97,7 @@ Parameters will be loaded recursively by path. The key will be parameter name wi
 use Dvsa\LaminasConfigCloudParameters\Provider\ParameterStore;
 
 return [
-    'config' => [
+    'config_parameters' => [
         'providers' => [
             ParameterStore::class => [
                 '/global',

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     }
   },
   "require": {
-    "php": "^8.0",
+    "php": "^8.2",
     "ext-json": "*",
     "laminas/laminas-modulemanager": "^2.4|^3.0",
     "laminas/laminas-config": "^2|^3",

--- a/composer.json
+++ b/composer.json
@@ -15,17 +15,17 @@
     "php": "^8.0",
     "ext-json": "*",
     "laminas/laminas-modulemanager": "^2.4|^3.0",
-    "laminas/laminas-config": "^2.0|^3.0",
+    "laminas/laminas-config": "^2|^3",
     "laminas/laminas-config-aggregator": "^1.7",
-    "symfony/dependency-injection": "^5.4",
-    "symfony/property-access": "^5.4|^6.3"
+    "symfony/dependency-injection": "^5|^6|^7",
+    "symfony/property-access": "^5|^6|^7"
   },
   "suggest": {
     "aws/aws-sdk-php": "To use the AWS parameter providers"
   },
   "require-dev": {
     "aws/aws-sdk-php": "^3.281",
-    "phpunit/phpunit": "^9.6",
+    "phpunit/phpunit": "^11.3",
     "laminas/laminas-mvc": "^3.3",
     "bamarni/composer-bin-plugin": "^1.8",
     "dvsa/coding-standards": "^2.0"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,13 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
-         backupGlobals="true"
-         colors="true"
-         executionOrder="random"
-         failOnRisky="true"
-         failOnWarning="true"
-         convertDeprecationsToExceptions="true"
->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.3/phpunit.xsd" backupGlobals="true" colors="true" executionOrder="random" failOnRisky="true" failOnWarning="true" cacheDirectory=".phpunit.cache">
   <testsuites>
     <testsuite name="Unit test suite">
       <directory>test/Unit</directory>

--- a/src/Module.php
+++ b/src/Module.php
@@ -49,10 +49,13 @@ class Module
 
         $bag = new ParameterBag($parameters);
 
-        $postProcessor = function (array $config) use ($bag) {
+        $postProcessor = function (array $config) use ($bag): mixed {
             try {
                 $bag->resolve();
 
+                /**
+                 * @var array<scalar, array<scalar, mixed>> $config
+                 */
                 $resolved = $bag->resolveValue($config);
 
                 if (!empty($config['config_parameters']['casts'])) {

--- a/test/Unit/ParameterProvider/Aws/SecretsManagerTest.php
+++ b/test/Unit/ParameterProvider/Aws/SecretsManagerTest.php
@@ -18,8 +18,8 @@ class SecretsManagerTest extends TestCase
     {
         $this->expectException(ParameterProviderException::class);
 
-        $secretsManagerClient = $this->getMockBuilder(SecretsManagerClient::class)->disableOriginalConstructor()->addMethods(['getSecretValue'])->getMock();
-        $secretsManagerClient->method('getSecretValue')->willThrowException(new AwsException('AWS_EXCEPTION', new Command('GetSecretValue')));
+        $secretsManagerClient = $this->createMock(SecretsManagerClient::class);
+        $secretsManagerClient->method('__call')->with('getSecretValue')->willThrowException(new AwsException('AWS_EXCEPTION', new Command('GetSecretValue')));
 
         $secretsManager = new SecretsManager($secretsManagerClient);
         $secretsManager('ID');
@@ -27,8 +27,8 @@ class SecretsManagerTest extends TestCase
 
     public function testStringSecretReturned(): void
     {
-        $secretsManagerClient = $this->getMockBuilder(SecretsManagerClient::class)->disableOriginalConstructor()->addMethods(['getSecretValue'])->getMock();
-        $secretsManagerClient->method('getSecretValue')->willReturn([
+        $secretsManagerClient = $this->createMock(SecretsManagerClient::class);
+        $secretsManagerClient->method('__call')->with('getSecretValue')->willReturn([
             'SecretString' => '{"foo":"bar"}',
         ]);
 
@@ -38,8 +38,8 @@ class SecretsManagerTest extends TestCase
 
     public function testBinaryStringSecretReturned(): void
     {
-        $secretsManagerClient = $this->getMockBuilder(SecretsManagerClient::class)->disableOriginalConstructor()->addMethods(['getSecretValue'])->getMock();
-        $secretsManagerClient->method('getSecretValue')->willReturn([
+        $secretsManagerClient = $this->createMock(SecretsManagerClient::class);
+        $secretsManagerClient->method('__call')->with('getSecretValue')->willReturn([
             'SecretBinary' => base64_encode('{"foo":"bar"}'),
         ]);
 


### PR DESCRIPTION
## Description

Drops support for PHP 8.0 and PHP 8.1. The PHP SDK has dropped support for PHP 8.0, and PHPUnit 11 has dropped support for PHP <8.2.
Expands dependency range to latest.
Fixes the inaccuracy in the README.
Bump PHPUnit to version 11.
